### PR TITLE
Bump dependencies to latest stable versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 binaryCompat = "0.13.2"
 configuration = "0.1.5"
-encoding = "2.0.0"
-endians = "0.1.0"
+encoding = "2.1.0"
+endians = "0.2.0"
 gradleVersions = "0.50.0"
-kotlin = "1.9.20"
+kotlin = "1.9.21"
 publish = "0.25.3"
 
 [libraries]


### PR DESCRIPTION
Most notably, kotlin -> `1.9.21`